### PR TITLE
Add basic examples to docs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,5 @@
+## Testing
+With Suborbital Compute running on localhost, run:
+```
+go test -v
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ In a Go project, run
 ```bash
 go get github.com/suborbital/compute-go
 ```
+
+Every operation with Compute is done with a `compute.Client`. Here's a simple example that fetches exisiting Runnables for a customer and namespace.
+
 ```go
 package main
 
@@ -34,6 +37,4 @@ func main() {
 }
 ```
 
-
 See [examples](examples/) folder for more.
-

--- a/README.md
+++ b/README.md
@@ -2,12 +2,38 @@
 Go client library for Suborbital Compute
 
 ## Usage
-> TODO
-## About
-The files within the `compute` directory were automatically generated from Suborbital Compute's OpenAPI specifications. This package wraps those libraries into one that is friendlier to use.
 
-## Testing
-With Suborbital Compute running on localhost, run:
+In a Go project, run
+```bash
+go get github.com/suborbital/compute-go
 ```
-go test -v
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/suborbital/compute-go"
+)
+
+func main() {
+    client, err := compute.NewLocalClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // get a list of Runnables
+    runnables, err := client.UserFunctions("customerID", "namespace")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, r := range runnables {
+        log.Println(r.FQFN)
+    }
+}
 ```
+
+
+See [examples](examples/) folder for more.
+

--- a/admin_requests.go
+++ b/admin_requests.go
@@ -9,9 +9,9 @@ import (
 	"github.com/suborbital/atmo/directive"
 )
 
-// EditorToken gets an editor token for the provided Runnable.
+// EditorToken gets an editor token for the provided Runnable. Note: this library
+// manages editor tokens for you, so you most likely do not need to use this function.
 func (c *Client) EditorToken(runnable *directive.Runnable) (string, error) {
-	// GET /api/v1/token/{environment}.{customerID}/{namespace}/{fnName}
 	if runnable == nil {
 		return "", errors.New("Runnable cannot be nil")
 	}
@@ -44,8 +44,8 @@ func (c *Client) EditorToken(runnable *directive.Runnable) (string, error) {
 	return token.Token, nil
 }
 
+// UserFunctions gets a list of the deployed runnables for the given customer and namespace.
 func (c *Client) UserFunctions(customerID string, namespace string) ([]*directive.Runnable, error) {
-	// GET /api/v1/functions/{customerID}/{namespace}
 	req, err := c.adminRequestBuilder(http.MethodGet,
 		path.Join("/api/v1/functions", customerID, namespace), nil)
 
@@ -71,12 +71,12 @@ func (c *Client) UserFunctions(customerID string, namespace string) ([]*directiv
 	return userFuncs.Functions, nil
 }
 
+// FunctionExecResults returns the 5 most recent successful execution results for the provided runnable.
 func (c *Client) FunctionExecResults(runnable *directive.Runnable) (*ExecResultsResponse, error) {
 	if runnable == nil {
 		return nil, errors.New("Runnable cannot be nil")
 	}
 
-	// GET /api/v1/results/com.awesomeco.vqeiupqvp98ph2e4nvrqw98/default/create-report/v0.0.1
 	req, err := c.adminRequestBuilder(http.MethodGet,
 		path.Join("/api/v1/results", runnable.FQFNURI), nil)
 
@@ -102,12 +102,12 @@ func (c *Client) FunctionExecResults(runnable *directive.Runnable) (*ExecResults
 	return execResults, nil
 }
 
+// FunctionExecResults returns the 5 most recent execution errors for the provided runnable.
 func (c *Client) FunctionExecErrors(runnable *directive.Runnable) (*ExecErrorResponse, error) {
 	if runnable == nil {
 		return nil, errors.New("Runnable cannot be nil")
 	}
 
-	// GET /api/v1/errors/com.awesomeco.vqeiupqvp98ph2e4nvrqw98/default/create-report/v0.0.1
 	req, err := c.adminRequestBuilder(http.MethodGet,
 		path.Join("/api/v1/errors", runnable.FQFNURI), nil)
 

--- a/client.go
+++ b/client.go
@@ -7,10 +7,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Client is used for interacting with the Suborbital Compute API
 type Client struct {
 	config *Config
 }
 
+// NewClient creates a Client with a Config
 func NewClient(config *Config) (*Client, error) {
 	if config == nil {
 		return nil, errors.New("failed to NewClient: config cannot be nil")
@@ -23,6 +25,7 @@ func NewClient(config *Config) (*Client, error) {
 	return client, nil
 }
 
+// NewLocalClient quickly sets up a Client with a LocalConfig. Useful for testing.
 func NewLocalClient() (*Client, error) {
 	return NewClient(LocalConfig())
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+
+	"github.com/suborbital/compute-go"
+)
+
+// a basic example without much error handling
+func main() {
+	conf, _ := compute.DefaultConfig("http://localhost") // use your own base URL here
+	client, _ := compute.NewClient(conf)
+
+	// create a runnable that can be passed into compute.Client
+	helloRunnable := compute.NewRunnable("com.suborbital", "acmeco", "default", "hello-world", "assemblyscript")
+
+	// fetch an assemblyscript runnable template pre-filled with data from the above runnable
+	template, _ := client.BuilderTemplate(helloRunnable)
+	log.Printf("building with template:\n%s\n", template.Contents)
+
+	// trigger a remote build of the runnable
+	buildResult, _ := client.BuildFunctionString(helloRunnable, template.Contents)
+
+	// if the build succeeds, run it
+	if buildResult.Succeeded {
+		log.Println("build succeeded!")
+
+		client.PromoteDraft(helloRunnable)
+
+		payload := "world!"
+
+		log.Printf("Executing runnable with payload: '%s'\n", payload)
+		output, _ := client.ExecString(helloRunnable, payload)
+
+		log.Println(string(output))
+	}
+}

--- a/examples/getrunnables/main.go
+++ b/examples/getrunnables/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+
+	"github.com/suborbital/compute-go"
+)
+
+func main() {
+	client, err := compute.NewLocalClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get a list of Runnables
+	runnables, err := client.UserFunctions("customerID", "namespace")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, r := range runnables {
+		log.Println(r.FQFN)
+	}
+}

--- a/execution_requests.go
+++ b/execution_requests.go
@@ -12,6 +12,7 @@ import (
 	"github.com/suborbital/atmo/directive"
 )
 
+// Exec remotely executes the provided runnable using the body as input. See also: ExecString()
 func (c *Client) Exec(runnable *directive.Runnable, body io.Reader) ([]byte, error) {
 	if runnable == nil {
 		return nil, errors.New("Runnable cannot be nil")
@@ -47,6 +48,7 @@ func (c *Client) Exec(runnable *directive.Runnable, body io.Reader) ([]byte, err
 	return result, nil
 }
 
+// ExecString sets up a buffer with the provided string and calls Exec
 func (c *Client) ExecString(runnable *directive.Runnable, body string) ([]byte, error) {
 	buf := bytes.NewBufferString(body)
 	return c.Exec(runnable, buf)

--- a/function.go
+++ b/function.go
@@ -1,6 +1,0 @@
-package compute
-
-type Function struct {
-	Language string
-	Body     string
-}

--- a/requests.go
+++ b/requests.go
@@ -1,1 +1,0 @@
-package compute


### PR DESCRIPTION
To preview this documentation as it was intended to be viewed, run:

```bash
go install -v golang.org/x/tools/cmd/godoc@latest
cd compute-go
godoc -http=localhost:6060

open http://localhost:6060/pkg/github.com/suborbital/compute-go/
```

Examples can be tested by going into each of the `examples/` subdirectories and running `go run .`
