### PR TITLE
Allow custom configs

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,3 +58,29 @@ func LocalConfig() *Config {
 
 	return conf
 }
+
+// Custom Configuration
+func CustomConfig(execHost string, adminHost string, builderHost string) (*Config, error) {
+	execUrl, err := url.Parse(execHost)
+	if err != nil {
+		return nil, err
+	}
+
+	adminUrl, err := url.Parse(adminHost)
+	if err != nil {
+		return nil, err
+	}
+
+	builderUrl, err := url.Parse(builderHost)
+	if err != nil {
+		return nil, err
+	}
+
+	conf := &Config{
+		executionURL: execUrl,
+		adminURL:     adminUrl,
+		builderURL:   builderUrl,
+	}
+
+	return conf, nil
+}


### PR DESCRIPTION
Allow fully customizing all three URLs of a `Config`. `DefaultConfig` only works inside Kubernetes clusters and only allows changing the Builder URL.  `LocalConfig` expects to be able to talk to `localhost`. We do not currently expose an option to fully customize all three endpoints if one needs to, this takes care of that.