### PR TITLE
chore: Rename env token

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,7 @@
 ## Testing
+
 With Suborbital Compute running on localhost, run:
-```
+
+```console
 go test -v
 ```

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ import (
 )
 
 func main() {
-	token, err := os.LookupEnv("SCC_ENV_TOKEN")
+    token, err := os.LookupEnv("SE2_ENV_TOKEN")
     if err != nil {
         log.Fatal(err)
     }
 
-	client, err := se2.NewClient(se2.LocalConfig(), token)
+    client, err := se2.NewClient(se2.LocalConfig(), token)
     if err != nil {
         log.Fatal(err)
     }

--- a/config.go
+++ b/config.go
@@ -14,12 +14,12 @@ type Config struct {
 // Everything except the scheme and hostname are considered. You need to provide your builder
 // host domain.
 func DefaultConfig(builderHost string) (*Config, error) {
-	execUrl, err := url.Parse("http://scc-atmo-service.suborbital.svc.cluster.local:80")
+	execUrl, err := url.Parse("http://e2core-service.suborbital.svc.cluster.local:80")
 	if err != nil {
 		return nil, err
 	}
 
-	adminUrl, err := url.Parse("http://scc-controlplane-service.suborbital.svc.cluster.local:8081")
+	adminUrl, err := url.Parse("http://se2-controlplane-service.suborbital.svc.cluster.local:8081")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/app/client.go
+++ b/examples/app/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 func client() *se2.Client {
-	token, _ := os.LookupEnv("SCC_ENV_TOKEN")
+	token, _ := os.LookupEnv("SE2_ENV_TOKEN")
 	client, _ := se2.NewClient(se2.LocalConfig(), token)
 
 	return client

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -11,9 +11,9 @@ var tmpl = "assemblyscript"
 
 // a basic example without much error handling
 func main() {
-	token, exists := os.LookupEnv("SCC_ENV_TOKEN")
+	token, exists := os.LookupEnv("SE2_ENV_TOKEN")
 	if !exists {
-		log.Panic("SCC_ENV_TOKEN not set")
+		log.Panic("SE2_ENV_TOKEN not set")
 	}
 
 	client, err := se2.NewClient(se2.LocalConfig(), token)

--- a/examples/getmodules/main.go
+++ b/examples/getmodules/main.go
@@ -8,9 +8,9 @@ import (
 )
 
 func main() {
-	token, exists := os.LookupEnv("SCC_ENV_TOKEN")
+	token, exists := os.LookupEnv("SE2_ENV_TOKEN")
 	if !exists {
-		log.Fatal("SCC_ENV_TOKEN environment variable not set")
+		log.Fatal("SE2_ENV_TOKEN environment variable not set")
 	}
 
 	client, err := se2.NewLocalClient(token)

--- a/se2_test.go
+++ b/se2_test.go
@@ -19,9 +19,9 @@ var envToken = ""
 var tmpl = "assemblyscript"
 
 func TestMain(m *testing.M) {
-	tok, exists := os.LookupEnv("SCC_ENV_TOKEN")
+	tok, exists := os.LookupEnv("SE2_ENV_TOKEN")
 	if !exists {
-		log.Fatal("SCC_ENV_TOKEN must be set to run tests!")
+		log.Fatal("SE2_ENV_TOKEN must be set to run tests!")
 	}
 	envToken = tok
 
@@ -41,7 +41,7 @@ func TestUserID(t *testing.T) {
 	t.Logf("Using UserID: %s", userID)
 }
 
-// TestBuilder must run before tests that depend on Modules existing in SCN
+// TestBuilder must run before tests that depend on modules existing in SE2
 func TestBuilder(t *testing.T) {
 	client, err := se2.NewLocalClient(envToken)
 	if err != nil {


### PR DESCRIPTION
With `v0.4.0` or greater of SE2 (formerly SCC), the env token has been
renamed.
